### PR TITLE
Fixes in special factorial function

### DIFF
--- a/static/code/math/specialFactorialModuloP.cpp
+++ b/static/code/math/specialFactorialModuloP.cpp
@@ -2,14 +2,11 @@ long long special_factorial_mod_p(long long n, long long p) {
   long long res = 1;
 
   // computation of c
-  long long c = 1;
-  for (long long i = 2; i < n % p; i += 1) {
-    c = (c * i) % p;
-  }
+  long long c = p-1;
 
   while (n > 1) {
     res = (res * binary_exponentiation_modulo_m(c, n / p, p)) % p;
-    for (long long i = 2; i < n % p; i += 1) {
+    for (long long i = 2; i <= n % p; i += 1) {
       res = (res * (long long)i) % p;
     }
     n /= p;


### PR DESCRIPTION
Here are some fixes to the special factorial function. The original code doesn't seem to compute 4! mod 5 correctly as demonstrated here:

https://rextester.com/OOOJPR23485

If p is a prime, then c should always be p-1 (or equivalently -1). Also, there is an off-by-one error when computing the tail end of the product not covered by the blocks of p^k.